### PR TITLE
Fix URLs on installation page

### DIFF
--- a/installation/index.html
+++ b/installation/index.html
@@ -156,7 +156,7 @@ git clone https://github.com/carboncopies/BrainGenix/</code></pre></p>
           <p><pre><code class="language-bash">sudo bash install.sh</code></pre></p>
 
           <p>After the install script finishes, you should have a working apache zookeeper installation.</p>
-          <p>This script does not yet automatically install Kafka, so we recommend following an installation tutorial, such as <link href=https://www.digitalocean.com/community/tutorials/how-to-install-apache-kafka-on-ubuntu-20-04 rel=this one>, if you are not already familiar.</p></div><br><br>
+          <p>This script does not yet automatically install Kafka, so we recommend following an installation tutorial, such as <a href=https://www.digitalocean.com/community/tutorials/how-to-install-apache-kafka-on-ubuntu-20-04>this one</a>, if you are not already familiar.</p></div><br><br>
 
 
 
@@ -199,9 +199,9 @@ DatabaseName: bgdb
 
 
           <div class="main"><h2>Setting Up MySQL</h2>
-          <link rel=How To Install MySQL on Ubuntu 20.04 | DigitalOcean href=https://www.digitalocean.com/community/tutorials/how-to-install-mysql-on-ubuntu-20-04>
+          <a href=https://www.digitalocean.com/community/tutorials/how-to-install-mysql-on-ubuntu-20-04>How To Install MySQL on Ubuntu 20.04 | DigitalOcean</a> 
 
-          <p>The recommended setup is to have a local instance of MySQL to run while coding in the local environment. Download MySQL Workbench, MySQL Server, and Connector/Python. The installer is found here: <link rel=MySQL:: Download MySQL Installer href=https://dev.mysql.com/downloads/installer/ >, then install the parts. Once connected to the local database via the Workbench, the Database/GenerateBrianDb.sql file in the code will set up the new database, tables, etc. Paste it into Workbench and run the entire file.
+          <p>The recommended setup is to have a local instance of MySQL to run while coding in the local environment. Download MySQL Workbench, MySQL Server, and Connector/Python. The MySQL installer is found <a href=https://dev.mysql.com/downloads/installer/ >here</a>, download, then install the parts. Once connected to the local database via the Workbench, the Database/GenerateBrianDb.sql file in the code will set up the new database, tables, etc. Paste it into Workbench and run the entire file.
 			  <p></div><br><br>
           
 <div class="main"><h2>Testing</h2>


### PR DESCRIPTION
Hi, I was attempting to install BrainGenix using the installation instruction on the website and noticed several broken links to external documentation. Fixed them in this PR, please have a look.